### PR TITLE
feat: allow ES6 import deconstructing/default

### DIFF
--- a/src/XMLHttpSource.js
+++ b/src/XMLHttpSource.js
@@ -66,6 +66,8 @@ XMLHttpSource.prototype = {
         return request(method, config);
     }
 };
-
-
+// ES6 modules
+XMLHttpSource.XMLHttpSource = XMLHttpSource;
+XMLHttpSource['default'] = XMLHttpSource;
+// commonjs
 module.exports = XMLHttpSource;


### PR DESCRIPTION
allow for

``` es6
import XMLHttpSource from 'falcor-browser';
```

and

``` es6
import {XMLHttpSource} from 'falcor-browser';
```

currently commonjs is the only one supported

``` es6
import * as XMLHttpSource from 'falcor-browser';
```
