### PR TITLE
Fixed Observable subscribe to accept both object and function signatures

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -10,26 +10,32 @@ function Observable() {}
 Observable.create = function(subscribe) {
   var o = new Observable();
 
-  o.subscribe = function(observer) {
+  o.subscribe = function(onNext, onError, onCompleted) {
 
-    if (typeof observer === 'function') {
+    var observer;
+    var disposable;
+
+    if (typeof onNext === 'function') {
         observer = {
-            onNext: observer,
-            onError: (arguments[1] || noop),
-            onCompleted: (arguments[2] || noop)
+            onNext: onNext,
+            onError: (onError || noop),
+            onCompleted: (onCompleted || noop)
         };
+    } else {
+        observer = onNext;
     }
 
-    var s = subscribe(observer);
-    if (typeof s === 'function') {
+    disposable = subscribe(observer);
+
+    if (typeof disposable === 'function') {
       return {
-        dispose: s
+        dispose: disposable
       };
-    }
-    else {
-      return s;
+    } else {
+      return disposable;
     }
   };
+
   return o;
 };
 

--- a/src/request.js
+++ b/src/request.js
@@ -3,11 +3,23 @@ var getXMLHttpRequest = require('./getXMLHttpRequest');
 var getCORSRequest = require('./getCORSRequest');
 var hasOwnProp = Object.prototype.hasOwnProperty;
 
+var noop = function() {};
+
 function Observable() {}
 
 Observable.create = function(subscribe) {
   var o = new Observable();
+
   o.subscribe = function(observer) {
+
+    if (typeof observer === 'function') {
+        observer = {
+            onNext: observer,
+            onError: (arguments[1] || noop),
+            onCompleted: (arguments[2] || noop)
+        };
+    }
+
     var s = subscribe(observer);
     if (typeof s === 'function') {
       return {
@@ -17,12 +29,13 @@ Observable.create = function(subscribe) {
     else {
       return s;
     }
-  }
+  };
   return o;
-}
+};
 
 function request(method, options, context) {
   return Observable.create(function requestObserver(observer) {
+
     var config = {
       method: method || 'GET',
       crossDomain: false,
@@ -30,6 +43,7 @@ function request(method, options, context) {
       headers: {},
       responseType: 'json'
     };
+
     var xhr,
       isDone,
       headers,
@@ -91,7 +105,7 @@ function request(method, options, context) {
           //
           // The json response type can be ignored if not supported, because JSON payloads are
           // parsed on the client-side regardless.
-          if (responseType !== 'json') {
+          if (config.responseType !== 'json') {
             throw e;
           }
         }


### PR DESCRIPTION
@jhusain @michaelbpaulson - For review.

After recent changes to remove Rx from the get flow, discovered that the
http datasource's Observable.subscribe wasn't implemented to accept both the
Observer object interface and separate onNext, onError and onCompleted.

With Rx, the observer was always the normalized Observer object interface.
Without Rx, it was separate onNext, onError, onCompleted callbacks.

Fixes https://github.com/Netflix/falcor/issues/512 and passes the integration
test in https://github.com/Netflix/falcor/pull/515