### PR TITLE
Encode query parameter values

### DIFF
--- a/src/buildQueryObject.js
+++ b/src/buildQueryObject.js
@@ -13,7 +13,7 @@ module.exports = function buildQueryObject(url, method, queryData) {
     keys = Object.keys(queryData);
     keys.forEach(function (k) {
       var value = (typeof queryData[k] === 'object') ? JSON.stringify(queryData[k]) : queryData[k];
-      qData.push(k + '=' + value);
+      qData.push(k + '=' + encodeURIComponent(value));
     });
   }
 


### PR DESCRIPTION
Some http-servers break when `[` or `]` are used in query parameter values because they are reserved characters with a special meaning in urls. By encoding the values things work as expected even with these servers.