### PR TITLE
Errors: always use instance with status & all props from response

### DIFF
--- a/src/XMLHttpSource.js
+++ b/src/XMLHttpSource.js
@@ -1,15 +1,8 @@
 'use strict';
 var request = require('./request');
 var buildQueryObject = require('./buildQueryObject');
+var simpleExtend = require('./simpleExtend');
 var isArray = Array.isArray;
-
-function simpleExtend(obj, obj2) {
-  var prop;
-  for (prop in obj2) {
-    obj[prop] = obj2[prop];
-  }
-  return obj;
-}
 
 function XMLHttpSource(jsongUrl, config) {
   this._jsongUrl = jsongUrl;
@@ -59,7 +52,7 @@ XMLHttpSource.prototype = {
     });
     var config = simpleExtend(queryObject, this._config);
     config.headers["Content-Type"] = "application/x-www-form-urlencoded";
-    
+
     // pass context for onBeforeRequest callback
     var context = this;
     return request(method, config, context);
@@ -86,7 +79,7 @@ XMLHttpSource.prototype = {
     var queryObject = this.buildQueryObject(this._jsongUrl, method, queryData.join('&'));
     var config = simpleExtend(queryObject, this._config);
     config.headers["Content-Type"] = "application/x-www-form-urlencoded";
-    
+
     // pass context for onBeforeRequest callback
     var context = this;
     return request(method, config, context);

--- a/src/simpleExtend.js
+++ b/src/simpleExtend.js
@@ -1,0 +1,7 @@
+module.exports = function simpleExtend(obj, obj2) {
+  var prop;
+  for (prop in obj2) {
+    obj[prop] = obj2[prop];
+  }
+  return obj;
+}


### PR DESCRIPTION
This improves error handling:
1. All error responses are mapped to an error object, but still have all properties of the error response from the server
2. `.status` is always added to the error object.
